### PR TITLE
fix print formatting error

### DIFF
--- a/urlwait2.py
+++ b/urlwait2.py
@@ -10,18 +10,18 @@ from requests import get
 def main(url):
     if not url.startswith('http'):
         url = 'http://' + url
-    print(f'urlwait2: waiting for {url}')
+    print('urlwait2: waiting for {0}'.format(url))
 
     attempt = 1
     while True:
         try:
             get(url, allow_redirects=True).raise_for_status()
         except Exception as e:
-            print(f'{e} Attempt {attempt} failed, retrying in 2 seconds')
+            print('{0} Attempt {1} failed, retrying in 2 seconds'.format(e, attempt))
             attempt += 1
             time.sleep(2)
         else:
-            print(f'urlwait2: successfully connected to {url}')
+            print('urlwait2: successfully connected to {0}'.format(url))
             break
 
 


### PR DESCRIPTION
Hi.
I installed the urlwait2 package with git, but when I tried to use the command, I was presented with the following error:
```
# urlwait2 google.com
Traceback (most recent call last):
  File "/usr/local/bin/urlwait2", line 7, in <module>
    from urlwait2 import main
  File "/usr/local/lib/python2.7/dist-packages/urlwait2.py", line 13
    print(f'urlwait2: waiting for {url}')
                                       ^
SyntaxError: invalid syntax
```
I just replaced the print strings with formatting that works..
It seems that the 'f' flag no longer works with python3, so I hope you wouldn't mind if I corrected the error, as it's still available in the PIP package repository.
Feel free to reach out and thanks for making this available to the community!