### PR TITLE
add requests package install_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,10 @@ setup(
     author_email='someuniquename@gmail.com',
     url='https://github.com/Fak3/urlwait2',
     license='MIT',
-    install_requires=['click'],
+    install_requires=[
+        'click',
+        'requests',
+        ],
     py_modules=['urlwait2'],
     include_package_data=True,
     entry_points={


### PR DESCRIPTION
Sorry.. just one thing to get the package working from pip..
I tried installing urlwait2 from the pip repository and it looks like it was missing the "requests" package. When I added requests to setup.py, it works. Cheers!